### PR TITLE
Update customer state to use pointer types

### DIFF
--- a/service_test.go
+++ b/service_test.go
@@ -725,4 +725,8 @@ func (suite *MainTestSuite) TestCustomerState() {
 	suite.NotNil(updatedCustomer.GetUpdatedTime(), "update time should not be nil")
 	suite.Truef(updatedCustomer.GetUpdatedTime().After(timeBeforeUpdate), "update time should be updated")
 
+	// try updating state with false value
+	prevState = clone(state)
+	state.Onboarding.Completed = false
+	testPutDoc(suite, statePath, prevState, state, nil)
 }


### PR DESCRIPTION
Since state updates are partial, it was not possible with the existing implementation to make partial updates.
For example, for a boolean field (since we have the `omitempty`) sending it with a `false` value, will omit it from the update logic, while it wasn't the original intention - to have it updated to `false`.

Now, the customer states are pointer types. Having null value means it has no value, and in any other case (not null) the field will get updated.
