### PR TITLE
Load the default customer config doc from config.json

### DIFF
--- a/routes/v1/customer_config/customer_config.go
+++ b/routes/v1/customer_config/customer_config.go
@@ -29,11 +29,20 @@ func getCustomerConfigByNameHandler(c *gin.Context) bool {
 	if configName == "" {
 		return false
 	}
+
 	//get the default config
-	defaultConfig, err := db.GetCachedDocument[*types.CustomerConfig](consts.DefaultCustomerConfigKey)
-	if err != nil {
-		handlers.ResponseInternalServerError(c, "failed to get default config", err)
-		return true
+	var defaultConfig *types.CustomerConfig
+	var err error
+	if DefaultCustomerConfig != nil {
+		// get the default config from config file if provided
+		defaultConfig = DefaultCustomerConfig
+	} else {
+		// get the default config from db if not provided by config file
+		defaultConfig, err = db.GetCachedDocument[*types.CustomerConfig](consts.DefaultCustomerConfigKey)
+		if err != nil {
+			handlers.ResponseInternalServerError(c, "failed to get default config", err)
+			return true
+		}
 	}
 
 	//case default config is requested - return it

--- a/routes/v1/customer_config/customer_config.go
+++ b/routes/v1/customer_config/customer_config.go
@@ -33,9 +33,9 @@ func getCustomerConfigByNameHandler(c *gin.Context) bool {
 	//get the default config
 	var defaultConfig *types.CustomerConfig
 	var err error
-	if DefaultCustomerConfig != nil {
+	if defaultCustomerConfig != nil {
 		// get the default config from config file if provided
-		defaultConfig = DefaultCustomerConfig
+		defaultConfig = defaultCustomerConfig
 	} else {
 		// get the default config from db if not provided by config file
 		defaultConfig, err = db.GetCachedDocument[*types.CustomerConfig](consts.DefaultCustomerConfigKey)

--- a/routes/v1/customer_config/routes.go
+++ b/routes/v1/customer_config/routes.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Holds the default customer config if it was loaded from config file
-var DefaultCustomerConfig *types.CustomerConfig
+var defaultCustomerConfig *types.CustomerConfig
 
 func AddRoutes(g *gin.Engine) {
 	customerConfigRouter := handlers.AddRoutes(g, handlers.NewRouterOptionsBuilder[*types.CustomerConfig]().
@@ -29,14 +29,18 @@ func AddRoutes(g *gin.Engine) {
 
 	// load default customer config from config file
 	if defaultConfigs := utils.GetConfig().DefaultConfigs; defaultConfigs != nil {
-		DefaultCustomerConfig = defaultConfigs.CustomerConfig
+		defaultCustomerConfig = defaultConfigs.CustomerConfig
 	}
 
 	// add lazy cache to default customer config
-	if DefaultCustomerConfig == nil {
+	if defaultCustomerConfig == nil {
 		db.AddCachedDocument[*types.CustomerConfig](consts.DefaultCustomerConfigKey,
 			consts.CustomerConfigCollection,
 			db.NewFilterBuilder().WithGlobalNotDelete().WithName(consts.GlobalConfigName).Get(),
 			time.Minute*5)
 	}
+}
+
+func SetDefaultConfigForTest(c *types.CustomerConfig) {
+	defaultCustomerConfig = c
 }

--- a/routes/v1/customer_config/routes.go
+++ b/routes/v1/customer_config/routes.go
@@ -4,11 +4,15 @@ import (
 	"config-service/db"
 	"config-service/handlers"
 	"config-service/types"
+	"config-service/utils"
 	"config-service/utils/consts"
 	"time"
 
 	"github.com/gin-gonic/gin"
 )
+
+// Holds the default customer config if it was loaded from config file
+var DefaultCustomerConfig *types.CustomerConfig
 
 func AddRoutes(g *gin.Engine) {
 	customerConfigRouter := handlers.AddRoutes(g, handlers.NewRouterOptionsBuilder[*types.CustomerConfig]().
@@ -23,9 +27,16 @@ func AddRoutes(g *gin.Engine) {
 	customerConfigRouter.GET("", getCustomerConfigHandler)
 	customerConfigRouter.DELETE("", deleteCustomerConfig)
 
+	// load default customer config from config file
+	if defaultConfigs := utils.GetConfig().DefaultConfigs; defaultConfigs != nil {
+		DefaultCustomerConfig = defaultConfigs.CustomerConfig
+	}
+
 	// add lazy cache to default customer config
-	db.AddCachedDocument[*types.CustomerConfig](consts.DefaultCustomerConfigKey,
-		consts.CustomerConfigCollection,
-		db.NewFilterBuilder().WithGlobalNotDelete().WithName(consts.GlobalConfigName).Get(),
-		time.Minute*5)
+	if DefaultCustomerConfig == nil {
+		db.AddCachedDocument[*types.CustomerConfig](consts.DefaultCustomerConfigKey,
+			consts.CustomerConfigCollection,
+			db.NewFilterBuilder().WithGlobalNotDelete().WithName(consts.GlobalConfigName).Get(),
+			time.Minute*5)
+	}
 }

--- a/service_test.go
+++ b/service_test.go
@@ -250,7 +250,7 @@ func (suite *MainTestSuite) TestCustomerConfiguration() {
 
 	// test get default config (from var)
 	// set default config variable
-	customer_config.DefaultCustomerConfig = defaultCustomerConfig2
+	customer_config.SetDefaultConfigForTest(defaultCustomerConfig2)
 	defaultCustomerConfig2.CustomerConfig.Settings.PostureScanConfig.ScanFrequency = "12345h"
 	//by name
 	path := fmt.Sprintf("%s?%s=%s", consts.CustomerConfigPath, consts.ConfigNameParam, consts.GlobalConfigName)
@@ -259,7 +259,7 @@ func (suite *MainTestSuite) TestCustomerConfiguration() {
 	path = fmt.Sprintf("%s?%s=%s", consts.CustomerConfigPath, consts.ScopeParam, consts.DefaultScope)
 	testGetDoc(suite, path, defaultCustomerConfig2, compareFilter)
 	// unset default config var
-	customer_config.DefaultCustomerConfig = nil
+	customer_config.SetDefaultConfigForTest(nil)
 
 	//test get default config (from cached db doc)
 	//by name

--- a/service_test.go
+++ b/service_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"config-service/routes/v1/customer_config"
 	"config-service/types"
 	"config-service/utils"
 	"config-service/utils/consts"
@@ -210,8 +211,10 @@ var cluster2ConfigJson []byte
 var cluster2ConfigMergedJson []byte
 
 func (suite *MainTestSuite) TestCustomerConfiguration() {
+
 	//load test data
 	defaultCustomerConfig := decode[*types.CustomerConfig](suite, defaultCustomerConfigJson)
+	defaultCustomerConfig2 := decode[*types.CustomerConfig](suite, defaultCustomerConfigJson)
 	customerConfig := decode[*types.CustomerConfig](suite, customerConfigJson)
 	customerConfigMerged := decode[*types.CustomerConfig](suite, customerConfigMergedJson)
 	cluster1Config := decode[*types.CustomerConfig](suite, cluster1ConfigJson)
@@ -245,9 +248,22 @@ func (suite *MainTestSuite) TestCustomerConfiguration() {
 	configNames := []string{defaultCustomerConfig.Name, customerConfig.Name, cluster1Config.Name, cluster2Config.Name}
 	testGetNameList(suite, consts.CustomerConfigPath, configNames)
 
-	//test get default config
+	// test get default config (from var)
+	// set default config variable
+	customer_config.DefaultCustomerConfig = defaultCustomerConfig2
+	defaultCustomerConfig2.CustomerConfig.Settings.PostureScanConfig.ScanFrequency = "12345h"
 	//by name
 	path := fmt.Sprintf("%s?%s=%s", consts.CustomerConfigPath, consts.ConfigNameParam, consts.GlobalConfigName)
+	testGetDoc(suite, path, defaultCustomerConfig2, compareFilter)
+	//by scope
+	path = fmt.Sprintf("%s?%s=%s", consts.CustomerConfigPath, consts.ScopeParam, consts.DefaultScope)
+	testGetDoc(suite, path, defaultCustomerConfig2, compareFilter)
+	// unset default config var
+	customer_config.DefaultCustomerConfig = nil
+
+	//test get default config (from cached db doc)
+	//by name
+	path = fmt.Sprintf("%s?%s=%s", consts.CustomerConfigPath, consts.ConfigNameParam, consts.GlobalConfigName)
 	testGetDoc(suite, path, defaultCustomerConfig, compareFilter)
 	//by scope
 	path = fmt.Sprintf("%s?%s=%s", consts.CustomerConfigPath, consts.ScopeParam, consts.DefaultScope)

--- a/utils/config.go
+++ b/utils/config.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"config-service/types"
 	"fmt"
 	"os"
 	"sync"
@@ -8,12 +9,17 @@ import (
 	"github.com/tkanos/gonfig"
 )
 
+type DefaultConfigs struct {
+	CustomerConfig *types.CustomerConfig `json:"customerConfig"`
+}
+
 type Configuration struct {
-	Port         string          `json:"port"`
-	Telemetry    TelemetryConfig `json:"telemetry"`
-	Mongo        MongoConfig     `json:"mongo"`
-	LoggerConfig LoggerConfig    `json:"logger"`
-	AdminUsers   []string        `json:"admins"`
+	Port           string          `json:"port"`
+	Telemetry      TelemetryConfig `json:"telemetry"`
+	Mongo          MongoConfig     `json:"mongo"`
+	LoggerConfig   LoggerConfig    `json:"logger"`
+	AdminUsers     []string        `json:"admins"`
+	DefaultConfigs *DefaultConfigs `json:"defaultConfigs"`
 }
 
 type TelemetryConfig struct {


### PR DESCRIPTION
In order to avoid an error (missing default doc) for clean installations, we provide the ability to load default customer config from the config.json

Ticket: [SUB-1574](https://cyberarmor-io.atlassian.net/browse/SUB-1574)