### PR TITLE
Support rename for collaboration

### DIFF
--- a/db/filter.go
+++ b/db/filter.go
@@ -150,6 +150,19 @@ func (f *FilterBuilder) AddOr(filters ...*FilterBuilder) *FilterBuilder {
 	return f
 }
 
+func (f *FilterBuilder) AddAnd(filters ...*FilterBuilder) *FilterBuilder {
+	orM := []bson.M{}
+	for _, filter := range filters {
+		m := bson.M{}
+		for i := range filter.filter {
+			m[filter.filter[i].Key] = filter.filter[i].Value
+		}
+		orM = append(orM, m)
+	}
+	f.filter = bson.D{{Key: "$and", Value: orM}}
+	return f
+}
+
 func (f *FilterBuilder) WithElementMatch(element interface{}) *FilterBuilder {
 	f.filter = append(f.filter, bson.E{Key: "$elemMatch", Value: element})
 	return f

--- a/db/mongo/index.go
+++ b/db/mongo/index.go
@@ -23,6 +23,11 @@ var collectionIndexes = map[string][]mongo.IndexModel{
 	consts.UsersNotificationsCacheCollection: {
 		{
 			Keys: bson.D{
+				{Key: "guid", Value: 1},
+			},
+		},
+		{
+			Keys: bson.D{
 				{Key: "name", Value: 1},
 			},
 		},
@@ -101,11 +106,43 @@ var collectionIndexes = map[string][]mongo.IndexModel{
 				{Key: "notificationType", Value: 1},
 			},
 		},
+		{
+			Keys: bson.D{
+				{Key: "customers", Value: 1},
+			},
+		},
+	},
+	consts.CollaborationConfigCollection: {
+		{
+			Keys: bson.D{
+				{Key: "guid", Value: 1},
+			},
+		},
+		{
+			Keys: bson.D{
+				{Key: "name", Value: 1},
+			},
+		},
+		{
+			Keys: bson.D{
+				{Key: "provider", Value: 1},
+			},
+		},
+		{
+			Keys: bson.D{
+				{Key: "customers", Value: 1},
+			},
+		},
 	},
 }
 
 // defaultIndex is the default index for all collections unless overridden in collectionIndexes
 var defaultIndex = []mongo.IndexModel{
+	{
+		Keys: bson.D{
+			{Key: "guid", Value: 1},
+		},
+	},
 	{
 		Keys: bson.D{
 			{Key: "name", Value: 1},

--- a/routes/v1/collaboration_config/routes.go
+++ b/routes/v1/collaboration_config/routes.go
@@ -11,5 +11,5 @@ import (
 func AddRoutes(g *gin.Engine) {
 	handlers.AddPolicyRoutes[*types.CollaborationConfig](g,
 		consts.CollaborationConfigPath,
-		consts.CollaborationConfigCollection, handlers.FlatQueryConfig())
+		consts.CollaborationConfigCollection, handlers.FlatQueryConfig(), true)
 }

--- a/routes/v1/posture_exception/routes.go
+++ b/routes/v1/posture_exception/routes.go
@@ -27,5 +27,5 @@ func AddRoutes(g *gin.Engine) {
 	}
 	handlers.AddPolicyRoutes[*types.PostureExceptionPolicy](g,
 		consts.PostureExceptionPolicyPath,
-		consts.PostureExceptionPolicyCollection, queryParamsConfig)
+		consts.PostureExceptionPolicyCollection, queryParamsConfig, false)
 }

--- a/routes/v1/vulnerability_exception/routes.go
+++ b/routes/v1/vulnerability_exception/routes.go
@@ -29,5 +29,5 @@ func AddRoutes(g *gin.Engine) {
 
 	handlers.AddPolicyRoutes[*types.VulnerabilityExceptionPolicy](g,
 		consts.VulnerabilityExceptionPolicyPath,
-		consts.VulnerabilityExceptionPolicyCollection, queryParamsConfig)
+		consts.VulnerabilityExceptionPolicyCollection, queryParamsConfig, false)
 }

--- a/service_test.go
+++ b/service_test.go
@@ -84,6 +84,10 @@ var commonCmpFilter = cmp.FilterPath(func(p cmp.Path) bool {
 	return p.String() == "PortalBase.GUID" || p.String() == "GUID" || p.String() == "CreationTime" || p.String() == "CreationDate" || p.String() == "PortalBase.UpdatedTime" || p.String() == "UpdatedTime"
 }, cmp.Ignore())
 
+var ignoreName = cmp.FilterPath(func(p cmp.Path) bool {
+	return p.String() == "PortalBase.Name"
+}, cmp.Ignore())
+
 func (suite *MainTestSuite) TestPostureException() {
 	posturePolicies, _ := loadJson[*types.PostureExceptionPolicy](posturePoliciesJson)
 
@@ -161,7 +165,14 @@ func (suite *MainTestSuite) TestCollaborationConfigs() {
 		return policy
 	}
 
-	commonTest(suite, consts.CollaborationConfigPath, collaborations, modifyFunc, commonCmpFilter)
+	testOptions := testOptions[*types.CollaborationConfig]{
+		mandatoryName: true,
+		uniqueName:    true,
+		renameAllowed: true,
+		customGUID:    false,
+	}
+
+	commonTestWithOptions(suite, consts.CollaborationConfigPath, collaborations, modifyFunc, testOptions, commonCmpFilter)
 
 	getQueries := []queryTest[*types.CollaborationConfig]{
 		{
@@ -178,7 +189,7 @@ func (suite *MainTestSuite) TestCollaborationConfigs() {
 		},
 	}
 	testGetDeleteByNameAndQuery(suite, consts.CollaborationConfigPath, consts.PolicyNameParam, collaborations, getQueries, commonCmpFilter)
-	testPartialUpdate(suite, consts.CollaborationConfigPath, &types.CollaborationConfig{}, commonCmpFilter)
+	testPartialUpdate(suite, consts.CollaborationConfigPath, &types.CollaborationConfig{PortalBase: armotypes.PortalBase{Name: "collabPartial"}}, commonCmpFilter, ignoreName)
 }
 
 //go:embed test_data/vulnerabilityPolicies.json

--- a/types/types.go
+++ b/types/types.go
@@ -120,7 +120,7 @@ func (v *AggregatedVulnerability) SetAttributes(attributes map[string]interface{
 type CollaborationConfig notifications.CollaborationConfig
 
 func (p *CollaborationConfig) GetReadOnlyFields() []string {
-	return commonReadOnlyFieldsV1
+	return commonReadOnlyFieldsAllowRename
 }
 func (p *CollaborationConfig) InitNew() {
 	p.CreationTime = time.Now().UTC().Format(time.RFC3339)
@@ -391,8 +391,10 @@ func (c *AttackChain) GetCreationTime() *time.Time {
 	return &creationTime
 }
 
-var commonReadOnlyFields = []string{consts.IdField, consts.NameField, consts.GUIDField}
+var baseReadOnlyFields = []string{consts.IdField, consts.GUIDField}
+var commonReadOnlyFields = append([]string{consts.NameField}, baseReadOnlyFields...)
 var commonReadOnlyFieldsV1 = append([]string{"creationTime"}, commonReadOnlyFields...)
+var commonReadOnlyFieldsAllowRename = append([]string{"creationTime"}, baseReadOnlyFields...)
 var clusterReadOnlyFields = append([]string{"subscription_date"}, commonReadOnlyFields...)
 var repositoryReadOnlyFields = append([]string{"creationDate", "provider", "owner", "repoName", "branchName"}, commonReadOnlyFields...)
 var croneJobReadOnlyFields = append([]string{"creationTime", "clusterName", "registryName"}, commonReadOnlyFields...)


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces the ability to rename collaborations. It includes changes to the backend logic to handle and validate the renaming process, ensuring that names remain unique. The changes have been made across several files, including handlers, routes, and types.

___
## PR Main Files Walkthrough:
`db/filter.go`: Added a new function `AddAnd` to the `FilterBuilder` struct to support MongoDB's `$and` operation.
`handlers/routes.go`: Added a new option `validatePutUniqueName` to the `routerOptions` struct and the `RouterOptionsBuilder` to validate unique names on PUT requests. The `AddRoutes` and `AddPolicyRoutes` functions have been updated to use this new option.
`handlers/validate.go`: Refactored the `ValidateUniqueValues` function to handle both POST and PUT requests. Added two new helper functions `buildValidateUniqueValuesPostQuery` and `buildValidateUniqueValuesPutQuery` to build the validation queries for POST and PUT requests respectively.
`routes/v1/collaboration_config/routes.go`: Updated the `AddRoutes` function call to allow renaming for collaboration configs.
`routes/v1/posture_exception/routes.go`: Updated the `AddRoutes` function call to disallow renaming for posture exception policies.
`routes/v1/vulnerability_exception/routes.go`: Updated the `AddRoutes` function call to disallow renaming for vulnerability exception policies.
`service_test.go`: Updated the `TestCollaborationConfigs` function to test the renaming of collaboration configs. Added a new `ignoreName` filter for the comparison function.
`testers_test.go`: Added a new `renameAllowed` option to the `testOptions` struct and updated the `commonTestWithOptions` function to test the renaming process.
`types/types.go`: Updated the `GetReadOnlyFields` function of `CollaborationConfig` to allow renaming. Also, updated the common read-only fields to differentiate between fields that allow renaming and those that don't.
