### PR TITLE
update armoapi to support attackChainsLastScan in customerState

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module config-service
 go 1.19
 
 require (
-	github.com/armosec/armoapi-go v0.0.227
+	github.com/armosec/armoapi-go v0.0.244
 	github.com/aws/smithy-go v1.13.5
 	github.com/chidiwilliams/flatbson v0.3.0
 	github.com/dchest/uniuri v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/armosec/armoapi-go v0.0.227 h1:daKPft3xPOdYXqlwyKtbe8TRhaHgsLE/cuDqtSqUxok=
-github.com/armosec/armoapi-go v0.0.227/go.mod h1:Y1ZcqPUTQ+F8JiQzErrToK5ULrPvClxZoshHmV9PIlU=
+github.com/armosec/armoapi-go v0.0.244 h1:H9kybf/2ASrBjUoP1mPYooO4AEqRZtxnnjO2himJ2A0=
+github.com/armosec/armoapi-go v0.0.244/go.mod h1:LKoj8FCbTKifhpBzRg3AT+rXYR6kxWwv6w39QU01FKw=
 github.com/armosec/gojay v1.2.15 h1:sSB2vnAvacUNkw9nzUYZKcPzhJOyk6/5LK2JCNdmoZY=
 github.com/armosec/gojay v1.2.15/go.mod h1:vzVAaay2TWJAngOpxu8aqLbye9jMgoKleuAOK+xsOts=
 github.com/armosec/utils-go v0.0.20 h1:bvr+TMumEYdMsGFGSsaQysST7K02nNROFvuajNuKPlw=


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR updates the ArmoAPI version from v0.0.227 to v0.0.244 in the config-service module. This update is intended to support the 'attackChainsLastScan' feature in the 'customerState'.

___
## PR Main Files Walkthrough:
`go.mod`: The ArmoAPI version is updated from v0.0.227 to v0.0.244.
`go.sum`: The checksum for ArmoAPI is updated to reflect the new version (v0.0.244).
