### PR TITLE
fix panic on out index range

### DIFF
--- a/handlers/v2ListRequest.go
+++ b/handlers/v2ListRequest.go
@@ -66,7 +66,7 @@ func v2List2FindOptions(request armotypes.V2ListRequest) (*db.FindOptions, error
 		}
 		if len(filters) > 1 {
 			findOptions.Filter().AddOr(filters...)
-		} else {
+		} else if len(filters) == 1 {
 			findOptions.Filter().WithFilter(filters[0])
 		}
 	}


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR addresses a bug that caused a panic due to an out of range index in the v2ListRequest handler. The fix ensures that the filter is only applied when there is at least one item in the filters array.

___
## PR Main Files Walkthrough:
`handlers/v2ListRequest.go`: Added a condition to check if the filters array has at least one item before applying the filter. This prevents an out of range panic when the filters array is empty.
