### PR TITLE
attack chains states - added unique name validator

### DIFF
--- a/routes/v1/attack_chains/routes.go
+++ b/routes/v1/attack_chains/routes.go
@@ -14,7 +14,7 @@ func AddRoutes(g *gin.Engine) {
 		WithDBCollection(consts.AttackChainsCollection).
 		WithV2ListSearch(true).
 		WithGetNamesList(false).
-		WithValidatePostUniqueName(false).
+		WithValidatePostUniqueName(true).
 		WithValidatePostMandatoryName(true).
 		Get()...)
 }

--- a/service_test.go
+++ b/service_test.go
@@ -1196,7 +1196,7 @@ func (suite *MainTestSuite) TestAttackChainsStates() {
 	}
 
 	testOpts := testOptions[*types.ClusterAttackChainState]{
-		uniqueName:    false,
+		uniqueName:    true,
 		mandatoryName: true,
 		customGUID:    false,
 		skipPutTests:  false,
@@ -1256,28 +1256,28 @@ func (suite *MainTestSuite) TestAttackChainsStates() {
 		{
 			PortalBase: armotypes.PortalBase{
 				GUID: "11111",
-				Name: "aaa",
+				Name: "minikube-aaa",
 			},
 			ClusterName: "minikube-a",
 		},
 		{
 			PortalBase: armotypes.PortalBase{
 				GUID: "11111121",
-				Name: "bbb",
+				Name: "minikube-bbb",
 			},
 			ClusterName: "minikube-b",
 		},
 		{
 			PortalBase: armotypes.PortalBase{
 				GUID: "1132111",
-				Name: "ccc",
+				Name: "minikube-a",
 			},
 			ClusterName: "minikube-a",
 		},
 		{
 			PortalBase: armotypes.PortalBase{
 				GUID: "223xx",
-				Name: "aaa",
+				Name: "minikube-b",
 			},
 			ClusterName: "minikube-b",
 		},
@@ -1285,7 +1285,7 @@ func (suite *MainTestSuite) TestAttackChainsStates() {
 		{
 			PortalBase: armotypes.PortalBase{
 				GUID: "2234",
-				Name: "aaa",
+				Name: "minikube-d",
 			},
 			ClusterName: "minikube-d",
 		},


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR introduces a change to enforce unique name validation for attack chains states. Previously, the system allowed duplicate names for attack chains states, but with this change, each state must have a unique name. This is reflected in both the routes configuration and the test cases.

___
## PR Main Files Walkthrough:
`routes/v1/attack_chains/routes.go`: The `WithValidatePostUniqueName` method is now set to `true` to enforce unique name validation for attack chains states.
`service_test.go`: The `uniqueName` test option is set to `true` to reflect the new unique name validation rule. Also, the test data has been updated to ensure that each attack chain state has a unique name.
