### PR TITLE
bump armo api version to version with severity score

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module config-service
 go 1.19
 
 require (
-	github.com/armosec/armoapi-go v0.0.253
+	github.com/armosec/armoapi-go v0.0.263
 	github.com/aws/smithy-go v1.13.5
 	github.com/chidiwilliams/flatbson v0.3.0
 	github.com/dchest/uniuri v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,8 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/armosec/armoapi-go v0.0.253 h1:XR2dFpNSSVazJLteV9wh13dz/EksknZLgDM/vCrzjwM=
-github.com/armosec/armoapi-go v0.0.253/go.mod h1:CJT5iH5VF30zjdQYXaQhsAm8IEHtM1T87HcFVXeLX54=
+github.com/armosec/armoapi-go v0.0.263 h1:lOtpOPcVeMChr6MP3Lt2pzFWCFZfdrbZpxFhxyRM2Xc=
+github.com/armosec/armoapi-go v0.0.263/go.mod h1:CJT5iH5VF30zjdQYXaQhsAm8IEHtM1T87HcFVXeLX54=
 github.com/armosec/gojay v1.2.15 h1:sSB2vnAvacUNkw9nzUYZKcPzhJOyk6/5LK2JCNdmoZY=
 github.com/armosec/gojay v1.2.15/go.mod h1:vzVAaay2TWJAngOpxu8aqLbye9jMgoKleuAOK+xsOts=
 github.com/armosec/utils-go v0.0.20 h1:bvr+TMumEYdMsGFGSsaQysST7K02nNROFvuajNuKPlw=


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR updates the Armo API version to a newer version that includes a severity score feature. The changes are reflected in the go.mod and go.sum files.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `go.mod`: The Armo API version has been updated from v0.0.253 to v0.0.263.
- `go.sum`: The checksums for the Armo API have been updated to reflect the new version (v0.0.263).
</details>

___
## User Description:
Signed-off-by: refaelm <refaelm@armosec.io>
