### PR TITLE
add admin apis for bulk set severity

### DIFF
--- a/db/utils.go
+++ b/db/utils.go
@@ -27,26 +27,16 @@ func ValidateCollection(collection string) error {
 //////////////////////////////////Sugar functions for mongo using values in gin context /////////////////////////////////////////
 /////////////////////////////////all methods are expecting collection and customerGUID from context/////////////////////////////
 
-func BulkSetVulnerabilityExceptionsSeverity(c context.Context, cves []string, severity int) error {
-	defer log.LogNTraceEnterExit("BulkSetVulnerabilityExceptionsSeverity", c)()
-	filterBuilder := NewFilterBuilder().WithIn("vulnerabilities.name", cves)
-	update := GetUpdateSetFieldCommand("vulnerabilities.$.severityScore", severity)
-	res, err := mongo.GetWriteCollection(consts.VulnerabilityExceptionPolicyCollection).UpdateMany(c, filterBuilder.get(), update)
-
-	if res != nil {
-		log.Log(fmt.Sprintf("BulkSetVulnerabilityExceptionsSeverity: updated %d documents", res.ModifiedCount), c)
+func AdminUpdateMany(c context.Context, filter *FilterBuilder, update bson.D) error {
+	defer log.LogNTraceEnterExit("AdminUpdateMany", c)()
+	collection, err := readCollection(c)
+	if err != nil {
+		return err
 	}
-	return err
-}
 
-func BulkSetPostureExceptionsSeverity(c context.Context, controlIDS []string, severity int) error {
-	defer log.LogNTraceEnterExit("BulkSetPostureExceptionsSeverity", c)()
-	filterBuilder := NewFilterBuilder().WithIn("posturePolicies.controlID", controlIDS)
-	update := GetUpdateSetFieldCommand("posturePolicies.$.severityScore", severity)
-	res, err := mongo.GetWriteCollection(consts.PostureExceptionPolicyCollection).UpdateMany(c, filterBuilder.get(), update)
-
+	res, err := mongo.GetWriteCollection(collection).UpdateMany(c, filter.get(), update)
 	if res != nil {
-		log.Log(fmt.Sprintf("BulkSetPostureExceptionsSeverity: updated %d documents", res.ModifiedCount), c)
+		log.Log(fmt.Sprintf("AdminUpdateMany: updated %d documents", res.ModifiedCount), c)
 	}
 	return err
 }

--- a/db/utils.go
+++ b/db/utils.go
@@ -27,18 +27,15 @@ func ValidateCollection(collection string) error {
 //////////////////////////////////Sugar functions for mongo using values in gin context /////////////////////////////////////////
 /////////////////////////////////all methods are expecting collection and customerGUID from context/////////////////////////////
 
-func AdminUpdateMany(c context.Context, filter *FilterBuilder, update bson.D) error {
+func AdminUpdateMany(c context.Context, filter *FilterBuilder, update bson.D) (int64, error) {
 	defer log.LogNTraceEnterExit("AdminUpdateMany", c)()
 	collection, err := readCollection(c)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	res, err := mongo.GetWriteCollection(collection).UpdateMany(c, filter.get(), update)
-	if res != nil {
-		log.Log(fmt.Sprintf("AdminUpdateMany: updated %d documents", res.ModifiedCount), c)
-	}
-	return err
+	return res.ModifiedCount, err
 }
 
 // GetAllForCustomer returns all docs for customer

--- a/db/utils.go
+++ b/db/utils.go
@@ -27,6 +27,30 @@ func ValidateCollection(collection string) error {
 //////////////////////////////////Sugar functions for mongo using values in gin context /////////////////////////////////////////
 /////////////////////////////////all methods are expecting collection and customerGUID from context/////////////////////////////
 
+func BulkSetVulnerabilityExceptionsSeverity(c context.Context, cves []string, severity int) error {
+	defer log.LogNTraceEnterExit("BulkSetVulnerabilityExceptionsSeverity", c)()
+	filterBuilder := NewFilterBuilder().WithIn("vulnerabilities.name", cves)
+	update := GetUpdateSetFieldCommand("vulnerabilities.$.severityScore", severity)
+	res, err := mongo.GetWriteCollection(consts.VulnerabilityExceptionPolicyCollection).UpdateMany(c, filterBuilder.get(), update)
+
+	if res != nil {
+		log.Log(fmt.Sprintf("BulkSetVulnerabilityExceptionsSeverity: updated %d documents", res.ModifiedCount), c)
+	}
+	return err
+}
+
+func BulkSetPostureExceptionsSeverity(c context.Context, controlIDS []string, severity int) error {
+	defer log.LogNTraceEnterExit("BulkSetPostureExceptionsSeverity", c)()
+	filterBuilder := NewFilterBuilder().WithIn("posturePolicies.controlID", controlIDS)
+	update := GetUpdateSetFieldCommand("posturePolicies.$.severityScore", severity)
+	res, err := mongo.GetWriteCollection(consts.PostureExceptionPolicyCollection).UpdateMany(c, filterBuilder.get(), update)
+
+	if res != nil {
+		log.Log(fmt.Sprintf("BulkSetPostureExceptionsSeverity: updated %d documents", res.ModifiedCount), c)
+	}
+	return err
+}
+
 // GetAllForCustomer returns all docs for customer
 func GetAllForCustomer[T any](c context.Context, includeGlobals bool) ([]T, error) {
 	findOps := NewFindOptions()

--- a/routes/v1/admin/routes.go
+++ b/routes/v1/admin/routes.go
@@ -66,11 +66,12 @@ func updateVulnerabilityExceptionsSeverity(c *gin.Context) {
 
 	filter := db.NewFilterBuilder().WithIn("vulnerabilities.name", updateReq.Cves)
 	update := db.GetUpdateSetFieldCommand("vulnerabilities.$.severityScore", updateReq.SeverityScore)
-	if err := db.AdminUpdateMany(c, filter, update); err != nil {
+	updatedCount, err := db.AdminUpdateMany(c, filter, update)
+	if err != nil {
 		handlers.ResponseInternalServerError(c, "failed to update vulnerability exceptions severity", err)
 		return
 	}
-	c.JSON(http.StatusOK, nil)
+	c.JSON(http.StatusOK, gin.H{"updatedCount": updatedCount})
 }
 
 func updatePostureExceptionsSeverity(c *gin.Context) {
@@ -82,11 +83,12 @@ func updatePostureExceptionsSeverity(c *gin.Context) {
 
 	filter := db.NewFilterBuilder().WithIn("posturePolicies.controlID", updateReq.ControlIDS)
 	update := db.GetUpdateSetFieldCommand("posturePolicies.$.severityScore", updateReq.SeverityScore)
-	if err := db.AdminUpdateMany(c, filter, update); err != nil {
+	updatedCount, err := db.AdminUpdateMany(c, filter, update)
+	if err != nil {
 		handlers.ResponseInternalServerError(c, "failed to update posture exceptions severity", err)
 		return
 	}
-	c.JSON(http.StatusOK, nil)
+	c.JSON(http.StatusOK, gin.H{"updatedCount": updatedCount})
 }
 
 func adminSearchCollection(c *gin.Context) {

--- a/routes/v1/admin/routes.go
+++ b/routes/v1/admin/routes.go
@@ -43,10 +43,47 @@ func AddRoutes(g *gin.Engine) {
 	//add delete customers data route
 	admin.DELETE("/customers", deleteAllCustomerData)
 
+	admin.PUT("/updateVulnerabilityExceptionsSeverity", updateVulnerabilityExceptionsSeverity)
+	admin.PUT("/updatePostureExceptionsSeverity", updatePostureExceptionsSeverity)
+
 	//Post V2 list query on other collections
 	admin.POST("/:path/query", adminSearchCollection)
 	//uniqueValues
 	admin.POST("/:path/uniqueValues", adminAggregateCollection)
+}
+
+func updateVulnerabilityExceptionsSeverity(c *gin.Context) {
+	updateReq := struct {
+		Cves          []string `json:"cves" binding:"required"`
+		SeverityScore int      `json:"severityScore" binding:"required"`
+	}{}
+
+	if err := c.ShouldBindJSON(&updateReq); err != nil {
+		handlers.ResponseFailedToBindJson(c, err)
+		return
+	}
+	if err := db.BulkSetVulnerabilityExceptionsSeverity(c, updateReq.Cves, updateReq.SeverityScore); err != nil {
+		handlers.ResponseInternalServerError(c, "failed to update vulnerability exceptions severity", err)
+		return
+	}
+	c.JSON(http.StatusOK, nil)
+}
+
+func updatePostureExceptionsSeverity(c *gin.Context) {
+	updateReq := struct {
+		ControlIDS    []string `json:"controlIDS" binding:"required"`
+		SeverityScore int      `json:"severityScore" binding:"required"`
+	}{}
+
+	if err := c.ShouldBindJSON(&updateReq); err != nil {
+		handlers.ResponseFailedToBindJson(c, err)
+		return
+	}
+	if err := db.BulkSetPostureExceptionsSeverity(c, updateReq.ControlIDS, updateReq.SeverityScore); err != nil {
+		handlers.ResponseInternalServerError(c, "failed to update posture exceptions severity", err)
+		return
+	}
+	c.JSON(http.StatusOK, nil)
 }
 
 func adminSearchCollection(c *gin.Context) {

--- a/types/types.go
+++ b/types/types.go
@@ -386,6 +386,16 @@ func (c *ClusterAttackChainState) GetCreationTime() *time.Time {
 	return &creationTime
 }
 
+type VulnerabilityExceptionsSeverityUpdate struct {
+	Cves          []string `json:"cves" binding:"required"`
+	SeverityScore int      `json:"severityScore" binding:"required"`
+}
+
+type PostureExceptionsSeverityUpdate struct {
+	ControlIDS    []string `json:"controlIDS" binding:"required"`
+	SeverityScore int      `json:"severityScore" binding:"required"`
+}
+
 var baseReadOnlyFields = []string{consts.IdField, consts.GUIDField}
 var commonReadOnlyFields = append([]string{consts.NameField}, baseReadOnlyFields...)
 var commonReadOnlyFieldsV1 = append([]string{"creationTime"}, commonReadOnlyFields...)


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces two new APIs to allow bulk updating of severity scores for vulnerability and posture exceptions. The main changes include:
- Addition of two new functions in `db/utils.go` to handle the bulk update operations: `BulkSetVulnerabilityExceptionsSeverity` and `BulkSetPostureExceptionsSeverity`.
- Addition of two new routes in `routes/v1/admin/routes.go` to handle the PUT requests for the bulk update operations: `updateVulnerabilityExceptionsSeverity` and `updatePostureExceptionsSeverity`.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `db/utils.go`: Added two new functions `BulkSetVulnerabilityExceptionsSeverity` and `BulkSetPostureExceptionsSeverity` to perform bulk update operations on the severity scores of vulnerability and posture exceptions respectively.
- `routes/v1/admin/routes.go`: Added two new routes `updateVulnerabilityExceptionsSeverity` and `updatePostureExceptionsSeverity` to handle the PUT requests for the bulk update operations.
</details>

___
## User Description:
Signed-off-by: refaelm <refaelm@armosec.io>
