### PR TITLE
support date field type using schema info

### DIFF
--- a/db/utils.go
+++ b/db/utils.go
@@ -194,7 +194,7 @@ func AdminAggregate(c context.Context, findOps *FindOptions) (*armotypes.UniqueV
 					fieldFilter.get(),
 					findOps.skip,
 					findOps.limit,
-					getSchemaFromContext(c)))
+					GetSchemaFromContext(c)))
 			if err != nil {
 				return fmt.Errorf("failed to aggregate field %s: %w", field, err)
 			}
@@ -609,7 +609,7 @@ func ReadContext(c context.Context) (collection, customerGUID string, err error)
 	return collection, customerGUID, err
 }
 
-func getSchemaFromContext(c context.Context) types.SchemaInfo {
+func GetSchemaFromContext(c context.Context) types.SchemaInfo {
 	if val := c.Value(consts.SchemaInfo); val != nil {
 		if schema, ok := val.(types.SchemaInfo); ok {
 			return schema

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -191,7 +191,7 @@ func HandlePostV2ListRequest[T types.DocContent](c *gin.Context) {
 		ResponseFailedToBindJson(c, err)
 		return
 	}
-	findOpts, err := v2List2FindOptions(req)
+	findOpts, err := v2List2FindOptions(req, db.GetSchemaFromContext(c))
 	if err != nil {
 		ResponseBadRequest(c, err.Error())
 		return
@@ -212,7 +212,7 @@ func HandlePostUniqueValuesRequestV2(c *gin.Context) {
 		ResponseFailedToBindJson(c, err)
 		return
 	}
-	findOpts, err := uniqueValuesRequest2FindOptions(req)
+	findOpts, err := uniqueValuesRequest2FindOptions(req, db.GetSchemaFromContext(c))
 	if err != nil {
 		ResponseBadRequest(c, err.Error())
 		return
@@ -234,7 +234,7 @@ func HandleAdminPostV2ListRequest[T types.DocContent](c *gin.Context) {
 		ResponseFailedToBindJson(c, err)
 		return
 	}
-	findOpts, err := v2List2FindOptions(req)
+	findOpts, err := v2List2FindOptions(req, db.GetSchemaFromContext(c))
 	if err != nil {
 		ResponseBadRequest(c, err.Error())
 		return
@@ -255,7 +255,7 @@ func HandleAdminPostUniqueValuesRequestV2(c *gin.Context) {
 		ResponseFailedToBindJson(c, err)
 		return
 	}
-	findOpts, err := uniqueValuesRequest2FindOptions(req)
+	findOpts, err := uniqueValuesRequest2FindOptions(req, db.GetSchemaFromContext(c))
 	if err != nil {
 		ResponseBadRequest(c, err.Error())
 		return
@@ -332,7 +332,7 @@ func HandleDeleteByQuery[T types.DocContent](c *gin.Context) {
 		ResponseFailedToBindJson(c, err)
 		return
 	}
-	findOpts, err := v2List2FindOptions(req)
+	findOpts, err := v2List2FindOptions(req, db.GetSchemaFromContext(c))
 	if err != nil {
 		ResponseBadRequest(c, err.Error())
 		return

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -191,7 +191,7 @@ func HandlePostV2ListRequest[T types.DocContent](c *gin.Context) {
 		ResponseFailedToBindJson(c, err)
 		return
 	}
-	findOpts, err := v2List2FindOptions(req, db.GetSchemaFromContext(c))
+	findOpts, err := v2List2FindOptions(c, req)
 	if err != nil {
 		ResponseBadRequest(c, err.Error())
 		return
@@ -212,7 +212,7 @@ func HandlePostUniqueValuesRequestV2(c *gin.Context) {
 		ResponseFailedToBindJson(c, err)
 		return
 	}
-	findOpts, err := uniqueValuesRequest2FindOptions(req, db.GetSchemaFromContext(c))
+	findOpts, err := uniqueValuesRequest2FindOptions(c, req)
 	if err != nil {
 		ResponseBadRequest(c, err.Error())
 		return
@@ -234,7 +234,7 @@ func HandleAdminPostV2ListRequest[T types.DocContent](c *gin.Context) {
 		ResponseFailedToBindJson(c, err)
 		return
 	}
-	findOpts, err := v2List2FindOptions(req, db.GetSchemaFromContext(c))
+	findOpts, err := v2List2FindOptions(c, req)
 	if err != nil {
 		ResponseBadRequest(c, err.Error())
 		return
@@ -255,7 +255,7 @@ func HandleAdminPostUniqueValuesRequestV2(c *gin.Context) {
 		ResponseFailedToBindJson(c, err)
 		return
 	}
-	findOpts, err := uniqueValuesRequest2FindOptions(req, db.GetSchemaFromContext(c))
+	findOpts, err := uniqueValuesRequest2FindOptions(c, req)
 	if err != nil {
 		ResponseBadRequest(c, err.Error())
 		return
@@ -332,7 +332,7 @@ func HandleDeleteByQuery[T types.DocContent](c *gin.Context) {
 		ResponseFailedToBindJson(c, err)
 		return
 	}
-	findOpts, err := v2List2FindOptions(req, db.GetSchemaFromContext(c))
+	findOpts, err := v2List2FindOptions(c, req)
 	if err != nil {
 		ResponseBadRequest(c, err.Error())
 		return

--- a/handlers/v2ListRequest.go
+++ b/handlers/v2ListRequest.go
@@ -2,12 +2,13 @@ package handlers
 
 import (
 	"config-service/db"
-	"config-service/types"
 	"config-service/utils"
 	"config-service/utils/consts"
 	"fmt"
+	"github.com/gin-gonic/gin"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/armosec/armoapi-go/armotypes"
 )
@@ -18,7 +19,7 @@ import (
 
 const maxV2PageSize = 150
 
-func v2List2FindOptions(request armotypes.V2ListRequest, schemaInfo types.SchemaInfo) (*db.FindOptions, error) {
+func v2List2FindOptions(ctx *gin.Context, request armotypes.V2ListRequest) (*db.FindOptions, error) {
 	if request.Until != nil {
 		return nil, fmt.Errorf("until is not supported")
 	}
@@ -59,7 +60,7 @@ func v2List2FindOptions(request armotypes.V2ListRequest, schemaInfo types.Schema
 	if len(request.InnerFilters) > 0 {
 		filters := []*db.FilterBuilder{}
 		for i := range request.InnerFilters {
-			if filter, err := buildInnerFilter(request.InnerFilters[i], schemaInfo); err != nil {
+			if filter, err := buildInnerFilter(ctx, request.InnerFilters[i]); err != nil {
 				return nil, err
 			} else if filter != nil {
 				filters = append(filters, filter)
@@ -74,7 +75,7 @@ func v2List2FindOptions(request armotypes.V2ListRequest, schemaInfo types.Schema
 	return findOptions, nil
 }
 
-func uniqueValuesRequest2FindOptions(request armotypes.UniqueValuesRequestV2, schemaInfo types.SchemaInfo) (*db.FindOptions, error) {
+func uniqueValuesRequest2FindOptions(ctx *gin.Context, request armotypes.UniqueValuesRequestV2) (*db.FindOptions, error) {
 	request.ValidatePageProperties(maxV2PageSize)
 	if request.Until != nil || request.Since != nil {
 		return nil, fmt.Errorf("since and until are not supported")
@@ -97,7 +98,7 @@ func uniqueValuesRequest2FindOptions(request armotypes.UniqueValuesRequestV2, sc
 	if len(request.InnerFilters) > 0 {
 		filters := []*db.FilterBuilder{}
 		for i := range request.InnerFilters {
-			if filter, err := buildInnerFilter(request.InnerFilters[i], schemaInfo); err != nil {
+			if filter, err := buildInnerFilter(ctx, request.InnerFilters[i]); err != nil {
 				return nil, err
 			} else if filter != nil {
 				filters = append(filters, filter)
@@ -114,7 +115,7 @@ func uniqueValuesRequest2FindOptions(request armotypes.UniqueValuesRequestV2, sc
 
 // TODO - use schema info to query arrays with $elemMatch
 // and to map ambiguous fields types (e.g time.time vs string)
-func buildInnerFilter(innerFilter map[string]string, schemaInfo types.SchemaInfo) (*db.FilterBuilder, error) {
+func buildInnerFilter(ctx *gin.Context, innerFilter map[string]string) (*db.FilterBuilder, error) {
 	filterBuilder := db.NewFilterBuilder()
 	for key, value := range innerFilter {
 		//ignore empty values
@@ -149,12 +150,24 @@ func buildInnerFilter(innerFilter map[string]string, schemaInfo types.SchemaInfo
 				if key == consts.GUIDField {
 					filters = append(filters, db.NewFilterBuilder().WithID(value))
 				} else {
-					filters = append(filters, db.NewFilterBuilder().WithValue(key, utils.String2Interface(value, key, schemaInfo)))
+					value, err := getTypedValue(ctx, key, value)
+					if err != nil {
+						return nil, err
+					}
+					filters = append(filters, db.NewFilterBuilder().WithValue(key, value))
 				}
 			case armotypes.V2ListGreaterOperator:
-				filters = append(filters, db.NewFilterBuilder().WithGreaterThanEqual(key, utils.String2Interface(value, key, schemaInfo)))
+				value, err := getTypedValue(ctx, key, value)
+				if err != nil {
+					return nil, err
+				}
+				filters = append(filters, db.NewFilterBuilder().WithGreaterThanEqual(key, value))
 			case armotypes.V2ListLowerOperator:
-				filters = append(filters, db.NewFilterBuilder().WithLowerThanEqual(key, utils.String2Interface(value, key, schemaInfo)))
+				value, err := getTypedValue(ctx, key, value)
+				if err != nil {
+					return nil, err
+				}
+				filters = append(filters, db.NewFilterBuilder().WithLowerThanEqual(key, value))
 			case armotypes.V2ListLikeOperator:
 				value = regexp.QuoteMeta(value)
 				fallthrough
@@ -169,8 +182,14 @@ func buildInnerFilter(innerFilter map[string]string, schemaInfo types.SchemaInfo
 				if rangeValues[0] == "" || rangeValues[1] == "" {
 					return nil, fmt.Errorf("invalid range value %s", value)
 				}
-				val1 := utils.String2Interface(rangeValues[0], key, schemaInfo)
-				val2 := utils.String2Interface(rangeValues[1], key, schemaInfo)
+				val1, err := getTypedValue(ctx, key, rangeValues[0])
+				if err != nil {
+					return nil, err
+				}
+				val2, err := getTypedValue(ctx, key, rangeValues[1])
+				if err != nil {
+					return nil, err
+				}
 				if !utils.SameType(val1, val2) {
 					return nil, fmt.Errorf("invalid range must use same value types found %T %T", val1, val2)
 				}
@@ -190,4 +209,16 @@ func buildInnerFilter(innerFilter map[string]string, schemaInfo types.SchemaInfo
 		return nil, nil
 	}
 	return filterBuilder, nil
+}
+
+func getTypedValue(ctx *gin.Context, field, value string) (interface{}, error) {
+	schemaInfo := db.GetSchemaFromContext(ctx)
+	if schemaInfo.IsDate(field) {
+		date, err := time.Parse(time.RFC3339, value)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse field %s with value %s into Time type", field, value)
+		}
+		return date, nil
+	}
+	return utils.String2Interface(value), nil
 }

--- a/routes/v1/vulnerability_exception/routes.go
+++ b/routes/v1/vulnerability_exception/routes.go
@@ -34,5 +34,6 @@ func AddRoutes(g *gin.Engine) {
 		false,
 		&types.SchemaInfo{
 			ArrayPaths: []string{"vulnerabilities"},
+			FieldsType: map[string]types.FieldType{"expirationDate": types.Date},
 		})
 }

--- a/service_test.go
+++ b/service_test.go
@@ -467,7 +467,7 @@ func (suite *MainTestSuite) TestVulnerabilityPolicies() {
 		return policy
 	}
 
-	commonTest(suite, consts.VulnerabilityExceptionPolicyPath, vulnerabilities, modifyFunc, commonCmpFilter)
+	commonTest(suite, consts.VulnerabilityExceptionPolicyPath, vulnerabilities, modifyFunc, commonCmpFilter, ignoreTime)
 
 	getQueries := []queryTest[*types.VulnerabilityExceptionPolicy]{
 		{
@@ -495,8 +495,8 @@ func (suite *MainTestSuite) TestVulnerabilityPolicies() {
 			expectedIndexes: []int{0},
 		},
 	}
-	testGetDeleteByNameAndQuery(suite, consts.VulnerabilityExceptionPolicyPath, consts.PolicyNameParam, vulnerabilities, getQueries, commonCmpFilter)
-	testPartialUpdate(suite, consts.VulnerabilityExceptionPolicyPath, &types.VulnerabilityExceptionPolicy{}, commonCmpFilter)
+	testGetDeleteByNameAndQuery(suite, consts.VulnerabilityExceptionPolicyPath, consts.PolicyNameParam, vulnerabilities, getQueries, commonCmpFilter, ignoreTime)
+	testPartialUpdate(suite, consts.VulnerabilityExceptionPolicyPath, &types.VulnerabilityExceptionPolicy{}, commonCmpFilter, ignoreTime)
 
 	uniqueValues := []uniqueValueTest{
 		{
@@ -539,7 +539,43 @@ func (suite *MainTestSuite) TestVulnerabilityPolicies() {
 		},
 	}
 
-	testUniqueValues(suite, consts.VulnerabilityExceptionPolicyPath, vulnerabilities, uniqueValues, commonCmpFilter)
+	testUniqueValues(suite, consts.VulnerabilityExceptionPolicyPath, vulnerabilities, uniqueValues, commonCmpFilter, ignoreTime)
+
+	projectedDocs := []*types.VulnerabilityExceptionPolicy{
+		{
+			PortalBase: armotypes.PortalBase{
+				Name: "1656325224.51881314",
+			},
+		},
+		{
+			PortalBase: armotypes.PortalBase{
+				Name: "1660467597.8207463",
+			},
+		},
+		{
+			PortalBase: armotypes.PortalBase{
+				Name: "1660475024.9930612",
+			},
+		},
+	}
+
+	searchQueries := []searchTest{
+		{
+			testName:         "test filter by range of dates",
+			expectedIndexes:  []int{1, 2},
+			projectedResults: true,
+			listRequest: armotypes.V2ListRequest{
+				FieldsList: []string{"name"},
+				InnerFilters: []map[string]string{
+					{
+						"expirationDate": "2022-08-10T11:03:45.494851Z&2022-08-11T08:59:58.297650Z|range",
+					},
+				},
+			},
+		},
+	}
+
+	testPostV2ListRequest(suite, consts.VulnerabilityExceptionPolicyPath, vulnerabilities, projectedDocs, searchQueries, commonCmpFilter, ignoreTime)
 }
 
 //go:embed test_data/customer_config/customerConfig.json

--- a/test_data/vulnerabilityPolicies.json
+++ b/test_data/vulnerabilityPolicies.json
@@ -39,6 +39,7 @@
         "name": "1660467597.8207463",
         "policyType": "vulnerabilityExceptionPolicy",
         "creationTime": "2022-08-14T08:59:58.297650",
+        "expirationDate": "2022-08-11T08:59:58.297650Z",
         "actions": [
             "ignore"
         ],
@@ -71,6 +72,7 @@
         "name": "1660475024.9930612",
         "policyType": "vulnerabilityExceptionPolicy",
         "creationTime": "2022-08-14T11:03:45.494851",
+        "expirationDate": "2022-08-10T11:03:45.494851Z",
         "actions": [
             "ignore"
         ],

--- a/testers_test.go
+++ b/testers_test.go
@@ -363,7 +363,7 @@ func testGetByQuery[T types.DocContent](suite *MainTestSuite, basePath string, t
 		docNames = append(docNames, testDocs[i].GetName())
 	}
 	//get Docs by query params
-	testGetWithQuery(suite, basePath, getQueries, newDocs)
+	testGetWithQuery(suite, basePath, getQueries, newDocs, compareOpts...)
 	for _, doc := range newDocs {
 		testDeleteDocByGUID(suite, basePath, doc, compareOpts...)
 	}
@@ -497,7 +497,7 @@ func testGetWithQuery[T types.DocContent](suite *MainTestSuite, basePath string,
 		for _, index := range query.expectedIndexes {
 			expectedDocs = append(expectedDocs, expected[index])
 		}
-		testGetDocs(suite, path, expectedDocs)
+		testGetDocs(suite, path, expectedDocs, compareOpts...)
 	}
 }
 

--- a/types/api_info.go
+++ b/types/api_info.go
@@ -14,8 +14,15 @@ type APIInfo struct {
 	Schema       SchemaInfo `json:"schema"`
 }
 
+type FieldType string
+
+const (
+	Date FieldType = "date"
+)
+
 type SchemaInfo struct {
-	ArrayPaths []string `json:"arrayPaths,omitempty"`
+	ArrayPaths []string             `json:"arrayPaths,omitempty"`
+	FieldsType map[string]FieldType `json:"fieldsType,omitempty"`
 }
 
 func SetAPIInfo(path string, apiInfo APIInfo) {

--- a/types/api_info.go
+++ b/types/api_info.go
@@ -57,3 +57,8 @@ func (s *SchemaInfo) GetArrayDetails(path string) (isArray bool, arrayPath, subP
 	}
 	return
 }
+
+func (s *SchemaInfo) IsDate(field string) bool {
+	fieldType, exist := s.FieldsType[field]
+	return exist && fieldType == Date
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"config-service/types"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -42,7 +43,7 @@ func Interface2String(value interface{}) string {
 	}
 }
 
-func String2Interface(value string) interface{} {
+func String2Interface(value string, field string, schemaInfo types.SchemaInfo) interface{} {
 	if i, err := strconv.ParseInt(value, 0, 64); err == nil {
 		return i
 	}
@@ -52,6 +53,15 @@ func String2Interface(value string) interface{} {
 	if b, err := strconv.ParseBool(value); err == nil {
 		return b
 	}
+	if fieldType, exist := schemaInfo.FieldsType[field]; exist {
+		switch fieldType {
+		case types.Date:
+			if d, err := time.Parse(time.RFC3339, value); err == nil {
+				return d
+			}
+		}
+	}
+
 	return value
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"config-service/types"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -43,7 +42,7 @@ func Interface2String(value interface{}) string {
 	}
 }
 
-func String2Interface(value string, field string, schemaInfo types.SchemaInfo) interface{} {
+func String2Interface(value string) interface{} {
 	if i, err := strconv.ParseInt(value, 0, 64); err == nil {
 		return i
 	}
@@ -52,14 +51,6 @@ func String2Interface(value string, field string, schemaInfo types.SchemaInfo) i
 	}
 	if b, err := strconv.ParseBool(value); err == nil {
 		return b
-	}
-	if fieldType, exist := schemaInfo.FieldsType[field]; exist {
-		switch fieldType {
-		case types.Date:
-			if d, err := time.Parse(time.RFC3339, value); err == nil {
-				return d
-			}
-		}
 	}
 
 	return value


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces support for date field types using schema information. The main changes include:
- The function `getSchemaFromContext` in `db/utils.go` has been made public (`GetSchemaFromContext`) to be used in other files.
- The `GetSchemaFromContext` function is now used in `handlers/handlers.go` to get schema information for various request handling functions.
- The `v2List2FindOptions` and `uniqueValuesRequest2FindOptions` functions in `handlers/v2ListRequest.go` now take an additional parameter `schemaInfo` of type `types.SchemaInfo`.
- The `buildInnerFilter` function in `handlers/v2ListRequest.go` now takes an additional parameter `schemaInfo` of type `types.SchemaInfo` and uses it to build filters.
- The `String2Interface` function in `utils/utils.go` now takes two additional parameters `field` and `schemaInfo` and uses them to convert string values to their appropriate types based on the schema information.
- A new `FieldType` type and a constant `Date` of type `FieldType` have been added in `types/api_info.go`.
- The `SchemaInfo` struct in `types/api_info.go` now includes a `FieldsType` field which is a map from field names to their types.
- The `TestVulnerabilityPolicies` function in `service_test.go` has been updated to test the new date field type support.
- The test data in `test_data/vulnerabilityPolicies.json` has been updated to include date fields.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `db/utils.go`: The function `getSchemaFromContext` has been made public (`GetSchemaFromContext`).
- `handlers/handlers.go`: The `GetSchemaFromContext` function is now used to get schema information for various request handling functions.
- `handlers/v2ListRequest.go`: The `v2List2FindOptions` and `uniqueValuesRequest2FindOptions` functions now take an additional parameter `schemaInfo` of type `types.SchemaInfo`. The `buildInnerFilter` function now takes an additional parameter `schemaInfo` of type `types.SchemaInfo` and uses it to build filters.
- `utils/utils.go`: The `String2Interface` function now takes two additional parameters `field` and `schemaInfo` and uses them to convert string values to their appropriate types based on the schema information.
- `types/api_info.go`: A new `FieldType` type and a constant `Date` of type `FieldType` have been added. The `SchemaInfo` struct now includes a `FieldsType` field which is a map from field names to their types.
- `service_test.go`: The `TestVulnerabilityPolicies` function has been updated to test the new date field type support.
- `test_data/vulnerabilityPolicies.json`: The test data has been updated to include date fields.
</details>

___
## User Description:
Signed-off-by: refaelm <refaelm@armosec.io>
