### PR TITLE
add posture policies date field schema info

### DIFF
--- a/routes/v1/posture_exception/routes.go
+++ b/routes/v1/posture_exception/routes.go
@@ -32,6 +32,7 @@ func AddRoutes(g *gin.Engine) {
 		false,
 		&types.SchemaInfo{
 			ArrayPaths: []string{"posturePolicies"},
+			FieldsType: map[string]types.FieldType{"expirationDate": types.Date},
 		},
 	)
 }


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces an enhancement to the Posture Policies schema in the application. Specifically, it adds an 'expirationDate' field of type 'Date' to the schema.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `routes/v1/posture_exception/routes.go`: Added 'expirationDate' field of type 'Date' to the 'posturePolicies' schema in the 'AddRoutes' function.
</details>

___
## User Description:
Signed-off-by: refaelm <refaelm@armosec.io>
